### PR TITLE
fixed batch norm reset for final forward pass (resolves issue #1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Keras callback object for SWA.
 **verbose** - Verbosity mode, 0 or 1.
 
 ### Batch Normalization
-Last epoch will be a forward pass, i.e. have learning rate set to zero, for models with batch normalization. This is due to the fact that batch normalization uses the running mean and variance of it's preceding layer to make a normalization. SWA will offset this normalization by suddenly changing the weights in the end of training. Therefore, it is necessary for the last epoch to be used to reset and recalculate batch normalization for the updated weights.
+Last epoch will be a forward pass, i.e. have learning rate set to zero, for models with batch normalization. This is due to the fact that batch normalization uses the running mean and variance of it's preceding layer to make a normalization. SWA will offset this normalization by suddenly changing the weights in the end of training. Therefore, it is necessary for the last epoch to be used to reset and recalculate batch normalization running mean and variance for the updated weights. Batch normalization gamma and beta values are preserved. 
 
 ### Learning Rate Schedules
 The default schedule is `'manual'`, allowing the learning rate to be controlled by an external learning rate scheduler or the optimizer. Then SWA will only affect the final weights and the learning rate of the last epoch if batch normalization is used. The schedules for the two predefined, `'constant'` or `'cyclic'` can be observed below.

--- a/swa/tfkeras.py
+++ b/swa/tfkeras.py
@@ -79,6 +79,10 @@ class SWA(Callback):
                 
         if self.is_batch_norm_epoch:
             self._set_swa_weights(epoch)
+
+            if self.verbose > 0:
+                print('\nResetting batch normalization layers. This may take a moment.')
+
             self._reset_batch_norm()
             
             if self.verbose > 0:
@@ -187,17 +191,23 @@ class SWA(Callback):
         for layer in self.batch_norm_layers:
             shape = (list(layer.input_spec.axes.values())[0],)
 
-            layer.moving_mean = layer.add_weight(
-                shape=shape,
-                name='moving_mean',
-                initializer=layer.moving_mean_initializer,
-                trainable=layer.moving_mean.trainable)
-            
-            layer.moving_variance = layer.add_weight(
-                shape=shape,
-                name='moving_variance',
-                initializer=layer.moving_variance_initializer,
-                trainable=layer.moving_variance.trainable)
+            #to get properly initialized moving mean and moving variance weights
+            #we initialize a new batch norm layer from the config of the existing
+            #layer, build that layer, retrieve its reinitialized moving mean and
+            #moving var weights and then delete the layer
+            new_batch_norm = BatchNormalization(**layer.get_config())
+            new_batch_norm.build(layer.input_shape)
+            new_gamma, new_beta, new_moving_mean, new_moving_var = new_batch_norm.get_weights()
+
+            #get rid of the new_batch_norm layer
+            del new_batch_norm
+
+            #get the trained gamma and beta from the layer
+            trained_gamma, trained_beta, trained_moving_mean, trained_moving_var = layer.get_weights()
+
+            #set weights to trained gamma and beta, reinitialized (new) mean and variance
+            layer.set_weights([trained_gamma, trained_beta,
+                               new_moving_mean, new_moving_var])
           
     def _restore_batch_norm(self):
         


### PR DESCRIPTION
Reinitialized batch norm running mean and running variance before final forward pass with SWA weights. Preserved learned batch norm beta and gamma values. 