### PR TITLE
Batch-wise Cyclic LR

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ The default schedule is `'manual'`, allowing the learning rate to be controlled 
 
 #### Example
 
-For Keras
+For Keras (with constant LR)
 ```python
 from sklearn.datasets.samples_generator import make_blobs
 from keras.utils import to_categorical
@@ -90,7 +90,7 @@ swa = SWA(start_epoch=start_epoch,
 model.fit(X, y, epochs=epochs, verbose=1, callbacks=[swa])
 ```
 
-Or for Keras in Tensorflow
+Or for Keras in Tensorflow (with Cyclic LR)
 
 ```python
 from sklearn.datasets.samples_generator import make_blobs
@@ -123,8 +123,10 @@ start_epoch = 75
 
 # define swa callback
 swa = SWA(start_epoch=start_epoch, 
-          lr_schedule='constant', 
-          swa_lr=0.01, 
+          lr_schedule='cyclic', 
+          swa_lr=0.001,
+          swa_lr2=0.003,
+          swa_freq=3,
           verbose=1)
 
 # train
@@ -134,24 +136,25 @@ model.fit(X, y, epochs=epochs, verbose=1, callbacks=[swa])
 Output
 ```
 Epoch 1/100
-1000/1000 [==============================] - 1s 703us/step - loss: 0.7518
+1000/1000 [==============================] - 1s 605us/sample - loss: 0.7635
 Epoch 2/100
-1000/1000 [==============================] - 0s 47us/step - loss: 0.5997
+1000/1000 [==============================] - 0s 94us/sample - loss: 0.6268
 ...
 Epoch 74/100
-1000/1000 [==============================] - 0s 31us/step - loss: 0.3913
-Epoch 75/100
+1000/1000 [==============================] - 0s 92us/sample - loss: 0.3902
+
 Epoch 00075: starting stochastic weight averaging
-1000/1000 [==============================] - 0s 202us/step - loss: 0.3907
+Epoch 75/100
+1000/1000 [==============================] - 0s 94us/sample - loss: 0.3905
 Epoch 76/100
-1000/1000 [==============================] - 0s 47us/step - loss: 0.3911
+1000/1000 [==============================] - 0s 94us/sample - loss: 0.3904
 ...
 Epoch 99/100
-1000/1000 [==============================] - 0s 31us/step - loss: 0.3910
+1000/1000 [==============================] - 0s 94us/sample - loss: 0.3904
 Epoch 100/100
-1000/1000 [==============================] - 0s 47us/step - loss: 0.3905
+1000/1000 [==============================] - 0s 93us/sample - loss: 0.3903
 
-Epoch 00100: final model weights set to stochastic weight average
+Epoch 00101: final model weights set to stochastic weight average
 ```
 
 ### Contributions

--- a/swa/keras.py
+++ b/swa/keras.py
@@ -21,51 +21,56 @@ class SWA(Callback):
         batch_size     integer, batch size (for batch norm with generator)
         verbose:       integer, verbosity mode, 0 or 1.
     """
-    def __init__(self, 
-                 start_epoch, 
-                 lr_schedule='manual', 
-                 swa_lr=0.001, 
-                 swa_lr2=0.003,
+    def __init__(self,
+                 start_epoch,
+                 lr_schedule='manual',
+                 swa_lr=0.001,
+                 swa_lr2=None,
                  swa_freq=1,
                  batch_size=None,
                  verbose=0):
-        
+
         super(SWA, self).__init__()
         self.start_epoch = start_epoch - 1
         self.lr_schedule = lr_schedule
         self.swa_lr = swa_lr
-        self.swa_lr2 = swa_lr2
+
+        #if no user determined upper bound, make one based off of the lower bound
+        self.swa_lr2 = (swa_lr2 if swa_lr2 != None else 10*swa_lr)
         self.swa_freq = swa_freq
         self.batch_size = batch_size
         self.verbose = verbose
-        
+
         if start_epoch < 2:
             raise ValueError('"swa_start" attribute cannot be lower than 2.')
-            
+
         schedules = ['manual', 'constant', 'cyclic']
-        
+
         if self.lr_schedule not in schedules:
-            raise ValueError('"{}" is not a valid learning rate schedule' \
+            raise ValueError('"{}" is not a valid learning rate schedule'
                              .format(self.lr_schedule))
 
         if self.lr_schedule == 'cyclic' and self.swa_freq < 2:
-            raise ValueError('"swa_freq" must be higher than 1 for cyclic schedule.')
+            raise ValueError(
+                '"swa_freq" must be higher than 1 for cyclic schedule.')
 
         if self.lr_schedule == 'cyclic' and self.swa_lr > self.swa_lr2:
             raise ValueError('"swa_lr" must be lower than "swa_lr2".')
 
     def on_train_begin(self, logs=None):
-        
+        self.lr_record = []
         self.epochs = self.params.get('epochs')
-        
+
         if self.start_epoch >= self.epochs - 1:
-            raise ValueError('"swa_start" attribute must be lower than "epochs".')
+            raise ValueError(
+                '"swa_start" attribute must be lower than "epochs".')
 
         self.init_lr = K.get_value(self.model.optimizer.lr)
 
         if self.init_lr < self.swa_lr:
-            raise ValueError('"swa_lr" must be lower than rate set in optimizer.')
-            
+            raise ValueError(
+                '"swa_lr" must be lower than rate set in optimizer.')
+
         self._check_batch_norm()
 
         if self.has_batch_norm and self.batch_size is None:
@@ -73,77 +78,89 @@ class SWA(Callback):
                              'models with batch normalization.')
 
     def on_epoch_begin(self, epoch, logs=None):
-        
-        self._scheduler(epoch)        
-        self._update_lr(epoch)       
+
+        self._scheduler(epoch)
+
+        if self.lr_schedule != 'cyclic':
+            self._update_lr(epoch)
+        self.current_epoch = epoch
 
         if self.is_swa_start_epoch:
             self.swa_weights = self.model.get_weights()
-            
+
             if self.verbose > 0:
                 print('\nEpoch %05d: starting stochastic weight averaging'
                       % (epoch + 1))
-                
+
         if self.is_batch_norm_epoch:
             self._set_swa_weights(epoch)
+
+            if self.verbose > 0:
+                print('\nResetting batch normalization layers. This may take a moment.')
             self._reset_batch_norm()
-            
+
             if self.verbose > 0:
                 print('\nEpoch %05d: running forward pass to adjust batch normalization'
                       % (epoch + 1))
 
     def on_batch_begin(self, batch, logs=None):
-        
+
+        #print(f'\n{batch}\n')
+        if self.lr_schedule == 'cyclic':
+            self._update_lr(self.current_epoch, batch)
+
         if self.is_batch_norm_epoch:
-            
-            batch_size = self.batch_size      
+
+            batch_size = self.batch_size
             momentum = batch_size / (batch*batch_size + batch_size)
 
             for layer in self.batch_norm_layers:
                 layer.momentum = momentum
-                
+
     def on_epoch_end(self, epoch, logs=None):
 
         if self.is_swa_start_epoch:
             self.swa_start_epoch = epoch
-        
+
         if self.is_swa_epoch and not self.is_batch_norm_epoch:
+            print('\nWeights being added to SWA.\n')
             self.swa_weights = self._average_weights(epoch)
 
     def on_train_end(self, logs=None):
-        
+
         if not self.has_batch_norm:
             self._set_swa_weights(self.epochs)
         else:
             self._restore_batch_norm()
-    
+
     def _scheduler(self, epoch):
-        
+
         swa_epoch = (epoch - self.start_epoch)
-        
+
         self.is_swa_epoch = epoch >= self.start_epoch and swa_epoch % self.swa_freq == 0
         self.is_swa_start_epoch = epoch == self.start_epoch
         self.is_batch_norm_epoch = epoch == self.epochs - 1 and self.has_batch_norm
-    
+
     def _average_weights(self, epoch):
 
         return [(swa_w * (epoch - self.start_epoch) + w)
                 / ((epoch - self.start_epoch) + 1)
-                    for swa_w, w in zip(self.swa_weights, self.model.get_weights())]
+                for swa_w, w in zip(self.swa_weights, self.model.get_weights())]
 
-    def _update_lr(self, epoch):  
-        
+    def _update_lr(self, epoch, batch=None):
+
         if self.is_batch_norm_epoch:
             K.set_value(self.model.optimizer.lr, 0)
         elif self.lr_schedule == 'constant':
             lr = self._constant_schedule(epoch)
             K.set_value(self.model.optimizer.lr, lr)
         elif self.lr_schedule == 'cyclic':
-            lr = self._cyclic_schedule(epoch)
+            lr = self._cyclic_schedule(epoch, batch)
+            self.lr_record.append(lr)
             K.set_value(self.model.optimizer.lr, lr)
 
     def _constant_schedule(self, epoch):
-        
+
         t = epoch / self.start_epoch
         lr_ratio = self.swa_lr / self.init_lr
         if t <= 0.5:
@@ -153,49 +170,72 @@ class SWA(Callback):
         else:
             factor = lr_ratio
         return self.init_lr * factor
-    
-    def _cyclic_schedule(self, epoch):
-        
-        swa_epoch = epoch - self.start_epoch
-        
+
+    def _cyclic_schedule(self, epoch, batch):
+
+        #print(batch)
+        steps = self.params.get('steps')
+        swa_epoch = (epoch - self.start_epoch) % self.swa_freq
+        cycle_length = self.swa_freq * steps
+
+        i = (swa_epoch * steps) + (batch + 1)
         if epoch >= self.start_epoch:
-            t = (((swa_epoch-1) % self.swa_freq)+1)/self.swa_freq
+            t = (((i-1) % cycle_length) + 1)/cycle_length
+
+            #print(f'swa_epoch: {swa_epoch} i:{i} cycle_len:{cycle_length} t:{t} batch:{batch} epoch:{epoch}')
             return (1-t)*self.swa_lr2 + t*self.swa_lr
         else:
             return self._constant_schedule(epoch)
 
-    
     def _set_swa_weights(self, epoch):
-        
+
         self.model.set_weights(self.swa_weights)
-        
+
         if self.verbose > 0:
             print('\nEpoch %05d: final model weights set to stochastic weight average'
-                  % (epoch + 1))     
-    
+                  % (epoch + 1))
+
     def _check_batch_norm(self):
-              
+
         self.batch_norm_momentums = []
         self.batch_norm_layers = []
         self.has_batch_norm = False
         self.running_bn_epoch = False
-        
+
         for layer in self.model.layers:
             if issubclass(layer.__class__, BatchNormalization):
                 self.has_batch_norm = True
                 self.batch_norm_momentums.append(layer.momentum)
                 self.batch_norm_layers.append(layer)
-                    
+
         if self.verbose > 0 and self.has_batch_norm:
             print('Model uses batch normalization. SWA will require last epoch '
                   'to be a forward pass and will run with no learning rate')
-    
+
     def _reset_batch_norm(self):
-        
+
         for layer in self.batch_norm_layers:
             shape = (list(layer.input_spec.axes.values())[0],)
 
-            layer.moving_mean = layer.add_weight(
+            #to get properly initialized moving mean and moving variance weights
+            #we initialize a new batch norm layer from the config of the existing
+            #layer, build that layer, retrieve its moving mean and moving var weights
+            #and then delete the layer
+            new_batch_norm = BatchNormalization(**layer.get_config())
+            new_batch_norm.build(layer.input_shape)
+            new_gamma, new_beta, new_moving_mean, new_moving_var = new_batch_norm.get_weights()
+
+            #now we can get rid of the new_batch_norm layer
+            del new_batch_norm
+
+            #get the trained gamma and beta from the layer
+            trained_gamma, trained_beta, trained_moving_mean, trained_moving_var = layer.get_weights()
+
+            #set weights
+            layer.set_weights([trained_gamma, trained_beta,
+                               new_moving_mean, new_moving_var])
+
+            """layer.moving_mean = layer.add_weight(
                 shape=shape,
                 name='moving_mean',
                 initializer=layer.moving_mean_initializer,
@@ -205,9 +245,9 @@ class SWA(Callback):
                 shape=shape,
                 name='moving_variance',
                 initializer=layer.moving_variance_initializer,
-                trainable=layer.moving_variance.trainable)
-          
+                trainable=layer.moving_variance.trainable)"""
+
     def _restore_batch_norm(self):
-        
+
         for layer, momentum in zip(self.batch_norm_layers, self.batch_norm_momentums):
             layer.momentum = momentum

--- a/swa/keras.py
+++ b/swa/keras.py
@@ -84,8 +84,10 @@ class SWA(Callback):
         self.current_epoch = epoch
         self._scheduler(epoch)
 
+        #update lr each epoch for non-cyclic LR schedules
         if self.lr_schedule != 'cyclic':
             self._update_lr(epoch)
+
         if self.is_swa_start_epoch:
             self.swa_weights = self.model.get_weights()
 
@@ -106,6 +108,7 @@ class SWA(Callback):
 
     def on_batch_begin(self, batch, logs=None):
 
+        #update LR each batch for cyclic LR schedule
         if self.lr_schedule == 'cyclic':
             self._update_lr(self.current_epoch, batch)
 

--- a/swa/keras.py
+++ b/swa/keras.py
@@ -105,7 +105,7 @@ class SWA(Callback):
 
     def on_batch_begin(self, batch, logs=None):
 
-        #print(f'\n{batch}\n')
+        
         if self.lr_schedule == 'cyclic':
             self._update_lr(self.current_epoch, batch)
 
@@ -123,7 +123,8 @@ class SWA(Callback):
             self.swa_start_epoch = epoch
 
         if self.is_swa_epoch and not self.is_batch_norm_epoch:
-            print('\nWeights being added to SWA.\n')
+            if self.verbose >0: 
+                print('\nWeights being added to SWA.\n')
             self.swa_weights = self._average_weights(epoch)
 
     def on_train_end(self, logs=None):
@@ -173,7 +174,7 @@ class SWA(Callback):
 
     def _cyclic_schedule(self, epoch, batch):
 
-        #print(batch)
+        
         steps = self.params.get('steps')
         swa_epoch = (epoch - self.start_epoch) % self.swa_freq
         cycle_length = self.swa_freq * steps
@@ -182,7 +183,7 @@ class SWA(Callback):
         if epoch >= self.start_epoch:
             t = (((i-1) % cycle_length) + 1)/cycle_length
 
-            #print(f'swa_epoch: {swa_epoch} i:{i} cycle_len:{cycle_length} t:{t} batch:{batch} epoch:{epoch}')
+           
             return (1-t)*self.swa_lr2 + t*self.swa_lr
         else:
             return self._constant_schedule(epoch)

--- a/swa/keras.py
+++ b/swa/keras.py
@@ -173,17 +173,19 @@ class SWA(Callback):
         return self.init_lr * factor
 
     def _cyclic_schedule(self, epoch, batch):
+        """Designed after Section 3.1 of Averaging Weights Leads to
+        Wider Optima and Better Generalization(https://arxiv.org/abs/1803.05407)
+        """
+        #mini-batches per epoch, equal to training_samples / batch_size
+        steps = self.params.get('steps') 
 
-        
-        steps = self.params.get('steps')
         swa_epoch = (epoch - self.start_epoch) % self.swa_freq
         cycle_length = self.swa_freq * steps
 
-        i = (swa_epoch * steps) + (batch + 1)
+        i = (swa_epoch * steps) + (batch + 1) #batch 0 indexed, so need to add 1
         if epoch >= self.start_epoch:
-            t = (((i-1) % cycle_length) + 1)/cycle_length
 
-           
+            t = (((i-1) % cycle_length) + 1)/cycle_length
             return (1-t)*self.swa_lr2 + t*self.swa_lr
         else:
             return self._constant_schedule(epoch)

--- a/swa/tfkeras.py
+++ b/swa/tfkeras.py
@@ -7,11 +7,9 @@ from tensorflow.keras.layers import BatchNormalization
 
 class SWA(Callback):
     """ Stochastic Weight Averging.
-
     # Paper
         title: Averaging Weights Leads to Wider Optima and Better Generalization
         link: https://arxiv.org/abs/1803.05407
-
     # Arguments
         start_epoch:   integer, epoch when swa should start.
         lr_schedule:   string, type of learning rate schedule.
@@ -20,27 +18,29 @@ class SWA(Callback):
         swa_freq:      integer, length of learning rate cycle.
         verbose:       integer, verbosity mode, 0 or 1.
     """
-    def __init__(self, 
-                 start_epoch, 
-                 lr_schedule='manual', 
-                 swa_lr=0.001, 
-                 swa_lr2=0.003,
+    def __init__(self,
+                 start_epoch,
+                 lr_schedule='manual',
+                 swa_lr=0.001,
+                 swa_lr2=None,
                  swa_freq=1,
                  verbose=0):
-        
+                 
         super(SWA, self).__init__()
         self.start_epoch = start_epoch - 1
         self.lr_schedule = lr_schedule
         self.swa_lr = swa_lr
-        self.swa_lr2 = swa_lr2
+
+        #if no user determined upper bound, make one based off of the lower bound
+        self.swa_lr2 = (swa_lr2 if swa_lr2 != None else 10*swa_lr)
         self.swa_freq = swa_freq
         self.verbose = verbose
-        
+
         if start_epoch < 2:
             raise ValueError('"swa_start" attribute cannot be lower than 2.')
-            
+
         schedules = ['manual', 'constant', 'cyclic']
-        
+
         if self.lr_schedule not in schedules:
             raise ValueError('"{}" is not a valid learning rate schedule' \
                              .format(self.lr_schedule))
@@ -52,9 +52,10 @@ class SWA(Callback):
             raise ValueError('"swa_lr" must be lower than "swa_lr2".')
 
     def on_train_begin(self, logs=None):
-        
+
+        #store LR data to be added to model.history object in on_train_end()
         self.epochs = self.params.get('epochs')
-        
+
         if self.start_epoch >= self.epochs - 1:
             raise ValueError('"swa_start" attribute must be lower than "epochs".')
 
@@ -62,86 +63,102 @@ class SWA(Callback):
 
         if self.init_lr < self.swa_lr:
             raise ValueError('"swa_lr" must be lower than rate set in optimizer.')
-            
+
         self._check_batch_norm()
 
     def on_epoch_begin(self, epoch, logs=None):
-        
-        self._scheduler(epoch)        
-        self._update_lr(epoch)       
+
+        self.current_epoch = epoch
+        self._scheduler(epoch)
+
+        #update lr each epoch for non-cyclic LR schedules
+        if self.lr_schedule != 'cyclic':
+            self._update_lr(epoch)
 
         if self.is_swa_start_epoch:
             self.swa_weights = self.model.get_weights()
-            
+
             if self.verbose > 0:
                 print('\nEpoch %05d: starting stochastic weight averaging'
                       % (epoch + 1))
-                
+
         if self.is_batch_norm_epoch:
             self._set_swa_weights(epoch)
 
             if self.verbose > 0:
-                print('\nEpoch %05d: reinitializing batch normalization layers' 
-                    % (epoch + 1))
+                print('\nEpoch %05d: reinitializing batch normalization layers'
+                      % (epoch + 1))
 
             self._reset_batch_norm()
-            
+
             if self.verbose > 0:
                 print('\nEpoch %05d: running forward pass to adjust batch normalization'
                       % (epoch + 1))
 
     def on_batch_begin(self, batch, logs=None):
-        
+
+        #update LR each batch for cyclic LR schedule
+        if self.lr_schedule == 'cyclic':
+            self._update_lr(self.current_epoch, batch)
+
         if self.is_batch_norm_epoch:
-            
-            batch_size = self.params['samples']      
+
+            batch_size = self.params['samples']
             momentum = batch_size / (batch*batch_size + batch_size)
 
             for layer in self.batch_norm_layers:
                 layer.momentum = momentum
-                
+
+    def on_batch_end(self, batch, logs=None):
+        logs = logs or {}
+        logs['lr'] = K.eval(self.model.optimizer.lr)
+        for k, v in logs.items():
+            if k == 'lr':
+                self.model.history.history.setdefault(k, []).append(v)
+
     def on_epoch_end(self, epoch, logs=None):
 
         if self.is_swa_start_epoch:
             self.swa_start_epoch = epoch
-        
+
         if self.is_swa_epoch and not self.is_batch_norm_epoch:
             self.swa_weights = self._average_weights(epoch)
 
     def on_train_end(self, logs=None):
-        
+
         if not self.has_batch_norm:
             self._set_swa_weights(self.epochs)
         else:
             self._restore_batch_norm()
-    
+
     def _scheduler(self, epoch):
-        
+
         swa_epoch = (epoch - self.start_epoch)
-        
+
         self.is_swa_epoch = epoch >= self.start_epoch and swa_epoch % self.swa_freq == 0
         self.is_swa_start_epoch = epoch == self.start_epoch
         self.is_batch_norm_epoch = epoch == self.epochs - 1 and self.has_batch_norm
-    
+
     def _average_weights(self, epoch):
 
         return [(swa_w * (epoch - self.start_epoch) + w)
                 / ((epoch - self.start_epoch) + 1)
-                    for swa_w, w in zip(self.swa_weights, self.model.get_weights())]
+                for swa_w, w in zip(self.swa_weights, self.model.get_weights())]
 
-    def _update_lr(self, epoch):  
-        
+    def _update_lr(self, epoch, batch=None):
+
         if self.is_batch_norm_epoch:
-            K.set_value(self.model.optimizer.lr, 0)
+            lr = 0
+            K.set_value(self.model.optimizer.lr, lr)
         elif self.lr_schedule == 'constant':
             lr = self._constant_schedule(epoch)
             K.set_value(self.model.optimizer.lr, lr)
         elif self.lr_schedule == 'cyclic':
-            lr = self._cyclic_schedule(epoch)
+            lr = self._cyclic_schedule(epoch, batch)
             K.set_value(self.model.optimizer.lr, lr)
 
     def _constant_schedule(self, epoch):
-        
+
         t = epoch / self.start_epoch
         lr_ratio = self.swa_lr / self.init_lr
         if t <= 0.5:
@@ -151,49 +168,57 @@ class SWA(Callback):
         else:
             factor = lr_ratio
         return self.init_lr * factor
-    
-    def _cyclic_schedule(self, epoch):
-        
-        swa_epoch = epoch - self.start_epoch
-        
+
+    def _cyclic_schedule(self, epoch, batch):
+        """Designed after Section 3.1 of Averaging Weights Leads to
+        Wider Optima and Better Generalization(https://arxiv.org/abs/1803.05407)
+        """
+        #steps are mini-batches per epoch, equal to training_samples / batch_size
+        steps = self.params.get('steps')
+
+        swa_epoch = (epoch - self.start_epoch) % self.swa_freq
+        cycle_length = self.swa_freq * steps
+
+        # batch 0 indexed, so need to add 1
+        i = (swa_epoch * steps) + (batch + 1)
         if epoch >= self.start_epoch:
-            t = (((swa_epoch-1) % self.swa_freq)+1)/self.swa_freq
+            t = (((i-1) % cycle_length) + 1)/cycle_length
             return (1-t)*self.swa_lr2 + t*self.swa_lr
         else:
             return self._constant_schedule(epoch)
-    
+
     def _set_swa_weights(self, epoch):
-        
+
         self.model.set_weights(self.swa_weights)
-        
+
         if self.verbose > 0:
             print('\nEpoch %05d: final model weights set to stochastic weight average'
-                  % (epoch + 1))     
-    
+                  % (epoch + 1))
+
     def _check_batch_norm(self):
-              
+
         self.batch_norm_momentums = []
         self.batch_norm_layers = []
         self.has_batch_norm = False
         self.running_bn_epoch = False
-        
+
         for layer in self.model.layers:
             if issubclass(layer.__class__, BatchNormalization):
                 self.has_batch_norm = True
                 self.batch_norm_momentums.append(layer.momentum)
                 self.batch_norm_layers.append(layer)
-                    
+
         if self.verbose > 0 and self.has_batch_norm:
             print('Model uses batch normalization. SWA will require last epoch '
                   'to be a forward pass and will run with no learning rate')
-    
+
     def _reset_batch_norm(self):
-        
+
         for layer in self.batch_norm_layers:
 
             # to get properly initialized moving mean and moving variance weights
             # we initialize a new batch norm layer from the config of the existing
-            # layer, build that layer, retrieve its reinitialized moving mean and 
+            # layer, build that layer, retrieve its reinitialized moving mean and
             # moving var weights and then delete the layer
             new_batch_norm = BatchNormalization(**layer.get_config())
             new_batch_norm.build(layer.input_shape)
@@ -208,8 +233,8 @@ class SWA(Callback):
             # set weights to trained gamma and beta, reinitialized mean and variance
             layer.set_weights([trained_gamma, trained_beta,
                                new_moving_mean, new_moving_var])
-          
+
     def _restore_batch_norm(self):
-        
+
         for layer, momentum in zip(self.batch_norm_layers, self.batch_norm_momentums):
             layer.momentum = momentum


### PR DESCRIPTION
Changes cyclic learning rate schedule to update learning rate batch-wise instead of epoch-wise. 

Additional notes:
* Add learning rate to history object returned by `model.fit()`
     - This is done using two different methods in`keras.py` and `tf.keras.py` due to additional features in `tf.keras` which make this logging easier. Method in `tf.keras` is preferred and stylistically more in line with native `tf.keras` logging which logs as training occurs. 
     - Workaround in `keras.py` uses a list to record the learning rate and then only at the end of training updates the history object
* Add automatic `swa_lr2` calcuator (`10*swa_lr`) in case where `swa_lr2` is not specified. Changed default `swa_lr2` to `None`. 
* Update `README.md` second example to show cyclic LR in action
* Left restriction for cyclic LR to only be applicable if `swa_freq` is larger than 1, though this is no longer strictly necessary. Restriction can be removed at discretion of the author. 